### PR TITLE
Refactor/immutable instance raid start

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,8 @@ jobs:
 
             echo "spring.redis.port = ${spring_redis_port}" >> ./src/main/resources/application.properties
             echo "spring.redis.host = ${spring_redis_host}" >> ./src/main/resources/application.properties
+
+      - run: ./gradlew clean
       - run: ./gradlew build
       - run: ./gradlew test
 

--- a/src/main/java/com/dimsssss/raid/raid/application/RaidRecordService.java
+++ b/src/main/java/com/dimsssss/raid/raid/application/RaidRecordService.java
@@ -25,8 +25,8 @@ public class RaidRecordService {
         LocalDateTime startTime = LocalDateTime.now();
 
         bossStateEntity.validateRaidEnter(startTime);
-        bossStateEntity.enterRaid(startTime);
 
+        bossStateRepository.save(bossStateEntity.withRaidingStateAndStartTime(true, startTime));
         RaidRecordEntity result = raidRecordRepository.save(requestDto.convertFrom());
         return result.toResponse();
     }

--- a/src/main/java/com/dimsssss/raid/raid/domain/BossStateEntity.java
+++ b/src/main/java/com/dimsssss/raid/raid/domain/BossStateEntity.java
@@ -1,7 +1,6 @@
 package com.dimsssss.raid.raid.domain;
 
 import com.dimsssss.raid.raid.domain.dto.BossStateResponseDto;
-import lombok.Builder;
 import lombok.Getter;
 import org.hibernate.annotations.CreationTimestamp;
 
@@ -35,7 +34,6 @@ public class BossStateEntity {
     @Version
     private Timestamp timestamp;
 
-    @Builder
     public BossStateEntity() {}
 
     private BossStateEntity(Long bossStateId, boolean isRaiding, int raidingMinute, Long latestRaidUserId, LocalDateTime raidStartAt,
@@ -77,8 +75,17 @@ public class BossStateEntity {
                 timestamp);
     }
 
-    public void setLatestRaidUserId(Long userId) {
-        this.latestRaidUserId = userId;
+    public BossStateEntity withUserId(Long userId) {
+        return new BossStateEntity(
+                bossStateId,
+                isRaiding,
+                raidingMinute,
+                userId,
+                raidStartAt,
+                raidEndAt,
+                createdAt,
+                deletedAt,
+                timestamp);
     }
 
     private boolean isTimeOut(LocalDateTime current) {

--- a/src/main/java/com/dimsssss/raid/raid/domain/BossStateEntity.java
+++ b/src/main/java/com/dimsssss/raid/raid/domain/BossStateEntity.java
@@ -64,12 +64,17 @@ public class BossStateEntity {
                 timestamp);
     }
 
-    public void onRaid() {
-        isRaiding = true;
-    }
-
-    public void setRaidStartAt(LocalDateTime raidStartAt) {
-        this.raidStartAt = raidStartAt;
+    public BossStateEntity withRaidingStateAndStartTime(boolean isRaiding, LocalDateTime startTime) {
+        return new BossStateEntity(
+                bossStateId,
+                isRaiding,
+                raidingMinute,
+                latestRaidUserId,
+                startTime,
+                raidEndAt,
+                createdAt,
+                deletedAt,
+                timestamp);
     }
 
     public void setLatestRaidUserId(Long userId) {
@@ -85,11 +90,6 @@ public class BossStateEntity {
 
         int raidTime = this.getRaidingMinute();
         return current.isAfter(latestStartRaidDateTime.plusMinutes(raidTime));
-    }
-
-    public void enterRaid(LocalDateTime current) {
-        this.onRaid();
-        this.setRaidStartAt(current);
     }
 
     public void validateRaidEnter(LocalDateTime current) throws RaidTimeoutException {

--- a/src/test/java/com/dimsssss/raid/raid/application/RaidRecordServiceTest.java
+++ b/src/test/java/com/dimsssss/raid/raid/application/RaidRecordServiceTest.java
@@ -33,13 +33,13 @@ class RaidRecordServiceTest {
     @MockBean
     RaidRecordRepository raidRecordRepository;
 
-    private RaidStartRequestDto requestDto;
+    RaidStartRequestDto requestDto;
 
-    private BossStateEntity bossStateEntity;
+    BossStateEntity bossStateEntity;
 
-    private RaidRecordEntity raidRecordEntity;
+    RaidRecordEntity raidRecordEntity;
 
-    private RaidEndRequestDto raidEndRequestDto;
+    RaidEndRequestDto raidEndRequestDto;
 
     @BeforeEach
     void setup() {
@@ -47,8 +47,7 @@ class RaidRecordServiceTest {
                 .userId(1L)
                 .level(3)
                 .build();
-        bossStateEntity = BossStateEntity.builder().build();
-        bossStateEntity.setLatestRaidUserId(1L);
+
         raidRecordEntity = RaidRecordEntity.builder()
                 .raidRecordId(1L)
                 .userId(1L)
@@ -60,9 +59,6 @@ class RaidRecordServiceTest {
                 .userId(1L)
                 .bossStateId(1L)
                 .build();
-
-        Mockito.when(bossStateRepository.getReferenceById(1L)).thenReturn(bossStateEntity);
-        Mockito.when(bossStateRepository.findBossState()).thenReturn(bossStateEntity);
         Mockito.when(raidRecordRepository.save(any(RaidRecordEntity.class))).thenReturn(raidRecordEntity);
     }
 

--- a/src/test/java/com/dimsssss/raid/raid/application/RaidRecordServiceTest.java
+++ b/src/test/java/com/dimsssss/raid/raid/application/RaidRecordServiceTest.java
@@ -65,6 +65,8 @@ class RaidRecordServiceTest {
     @Test
     @DisplayName("시작 시간이 없고 진행중인 레이드가 없다면 레이드가 가능하다")
     void startRaid() throws RaidTimeoutException {
+        bossStateEntity = new BossStateEntity().withRaidingStateAndStartTime(false, null);
+        Mockito.when(bossStateRepository.findBossState()).thenReturn(bossStateEntity);
         RaidStartResponseDto responseDto = raidRecordService.startRaid(requestDto);
 
         assertThat(responseDto.getRaidRecordId()).isEqualTo(1L);
@@ -74,9 +76,8 @@ class RaidRecordServiceTest {
     @DisplayName("raid 시간 내에 다른 raid 시작 요청이 오면 예외를 반환한다")
     @Test
     void startRaid_fail_when_raid_on() {
-        bossStateEntity.enterRaid(LocalDateTime.now());
-        bossStateEntity.onRaid();
-
+        bossStateEntity = new BossStateEntity().withRaidingStateAndStartTime(true, LocalDateTime.now());
+        Mockito.when(bossStateRepository.findBossState()).thenReturn(bossStateEntity);
         assertThatThrownBy(() -> raidRecordService.startRaid(requestDto))
                 .isInstanceOf(RaidTimeoutException.class)
                 .hasMessage("현재 레이드가 진행중입니다");
@@ -85,8 +86,9 @@ class RaidRecordServiceTest {
     @DisplayName("raid 시간이 종료되면 새로운 raid 가 가능하다")
     @Test
     void startRaid_success_when_time_out() throws RaidTimeoutException {
-        bossStateEntity.enterRaid(LocalDateTime.of(2022, 12, 11, 1,1,1));
-        bossStateEntity.onRaid();
+        LocalDateTime raidStartTime = LocalDateTime.of(2022, 12, 24, 20, 20);
+        bossStateEntity = new BossStateEntity().withRaidingStateAndStartTime(true, raidStartTime);
+        Mockito.when(bossStateRepository.findBossState()).thenReturn(bossStateEntity);
 
         RaidStartResponseDto responseDto = raidRecordService.startRaid(requestDto);
 
@@ -103,7 +105,9 @@ class RaidRecordServiceTest {
     @DisplayName("raid 시간이 남지 않았을 때 종료 요청이 오면 예외를 반환한다")
     @Test
     void endRaid_fail_when_time_out() {
-        bossStateEntity.enterRaid(LocalDateTime.of(2022, 12, 11, 1,1,1));
+        LocalDateTime raidStartTime = LocalDateTime.of(2022, 12, 24, 20, 20);
+        bossStateEntity = new BossStateEntity().withRaidingStateAndStartTime(false, raidStartTime);
+        Mockito.when(bossStateRepository.findBossState()).thenReturn(bossStateEntity);
         assertThatThrownBy(() -> raidRecordService.endRaid(raidEndRequestDto))
                 .isInstanceOf(RaidTimeoutException.class)
                 .hasMessage("주어진 레이드 시간이 지났습니다");
@@ -112,23 +116,25 @@ class RaidRecordServiceTest {
     @DisplayName("raid 종료 요청자와 raid 진행중인 사용자가 다르면 예외를 반환한다")
     @Test
     void endRaid_fail_when_raider_not_be_requester() {
-        bossStateEntity.setRaidStartAt(LocalDateTime.now());
         RaidEndRequestDto otherRequestDto = RaidEndRequestDto.builder()
                 .raidRecordId(1L)
                 .userId(2L)
                 .bossStateId(1L)
                 .build();
 
+        bossStateEntity = new BossStateEntity().withRaidingStateAndStartTime(true, LocalDateTime.now()).withUserId(1L);
+        Mockito.when(bossStateRepository.findBossState()).thenReturn(bossStateEntity);
+
         assertThatThrownBy(() -> raidRecordService.endRaid(otherRequestDto))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("레이드 진행중인 아이디와 종료 아이디가 다릅니다. raidUserId: %s, requestUserId: %s");
     }
 
-    @DisplayName("현재 레이드가 진행중일 경우 예외 처리한다")
+    @DisplayName("현재 레이드가 진행중일 경우 예외를 반환한다")
     @Test
     void getBossState_not_cant_enter() {
-        bossStateEntity.setRaidStartAt(LocalDateTime.now());
-        bossStateEntity.onRaid();
+        bossStateEntity = new BossStateEntity().withRaidingStateAndStartTime(true, LocalDateTime.now());
+        Mockito.when(bossStateRepository.findBossState()).thenReturn(bossStateEntity);
         assertThatThrownBy(() -> raidRecordService.getBossState())
                 .isInstanceOf(RaidTimeoutException.class)
                 .hasMessage("현재 레이드가 진행중입니다");
@@ -137,6 +143,8 @@ class RaidRecordServiceTest {
     @DisplayName("현재 레이드가 가능할 때 enteredUserId, canEnter 값을 반환한다")
     @Test
     void getBossState_can_enter() throws Exception {
+        bossStateEntity = new BossStateEntity().withRaidingStateAndStartTime(false, null).withUserId(1L);
+        Mockito.when(bossStateRepository.findBossState()).thenReturn(bossStateEntity);
         BossStateResponseDto bossStateResponseDto = raidRecordService.getBossState();
         assertThat(bossStateResponseDto.isCanEnter()).isTrue();
         assertThat(bossStateResponseDto.getEnteredUserId()).isEqualTo(1L);

--- a/src/test/java/com/dimsssss/raid/raid/domain/BossStateRepositoryTest.java
+++ b/src/test/java/com/dimsssss/raid/raid/domain/BossStateRepositoryTest.java
@@ -27,7 +27,7 @@ class BossStateRepositoryTest {
     @DisplayName("보스의 상태를 저장할 수 있다")
     @Test
     public void create() {
-        BossStateEntity bossStateEntity = BossStateEntity.builder().build();
+        BossStateEntity bossStateEntity = new BossStateEntity();
         bossStateRepository.save(bossStateEntity);
 
         BossStateEntity result = bossStateRepository.findAll().get(0);

--- a/src/test/java/com/dimsssss/raid/raid/domain/RaidRecordRepositoryTest.java
+++ b/src/test/java/com/dimsssss/raid/raid/domain/RaidRecordRepositoryTest.java
@@ -27,7 +27,7 @@ class RaidRecordRepositoryTest {
 
     @BeforeAll
     void setup() {
-        BossStateEntity bossStateEntity = BossStateEntity.builder().build();
+        BossStateEntity bossStateEntity = new BossStateEntity();
         bossStateRepository.save(bossStateEntity);
 
         List<RaidRecordEntity> records = new ArrayList<>();

--- a/src/test/java/com/dimsssss/raid/raid/presentation/RaidRecordControllerTest.java
+++ b/src/test/java/com/dimsssss/raid/raid/presentation/RaidRecordControllerTest.java
@@ -144,10 +144,7 @@ class RaidRecordControllerTest {
     @Test
     public void getBossState_fail_when_raiding () throws Exception {
         String url = "http://localhost:" + port + "/bossRaid";
-        BossStateEntity bossStateEntity = new BossStateEntity();
-        bossStateEntity.setLatestRaidUserId(1L);
-        bossStateEntity.onRaid();
-        bossStateEntity.setRaidStartAt(LocalDateTime.now());
+        BossStateEntity bossStateEntity = new BossStateEntity().withRaidingStateAndStartTime(true, LocalDateTime.now()).withUserId(1L);
         Mockito.when(bossStateRepository.findBossState()).thenReturn(bossStateEntity);
         mockMvc.perform(get(url).with(csrf()))
                 .andExpect(status().is4xxClientError())


### PR DESCRIPTION
## 객체 복사 적용(레이드 시작)

- 레이드 시작 API에 남아 있던 setter 메서드를 제거하고 객체 복사 코드 추가
- 변경된 코드에 맞게 테스트 코드도 수정