### PR TITLE
Refactor/remove time

### DIFF
--- a/src/main/java/com/dimsssss/raid/raid/application/RaidRecordService.java
+++ b/src/main/java/com/dimsssss/raid/raid/application/RaidRecordService.java
@@ -22,11 +22,10 @@ public class RaidRecordService {
     @Transactional
     public RaidStartResponseDto startRaid (RaidStartRequestDto requestDto) throws RaidTimeoutException {
         BossStateEntity bossStateEntity = bossStateRepository.findBossState();
-        LocalDateTime startTime = LocalDateTime.now();
 
-        bossStateEntity.validateRaidEnter(startTime);
+        bossStateEntity.validateRaidEnter(requestDto.getRaidStartTime());
 
-        bossStateRepository.save(bossStateEntity.withRaidingStateAndStartTime(true, startTime));
+        bossStateRepository.save(bossStateEntity.withRaidingStateAndStartTime(true, requestDto.getRaidStartTime()));
         RaidRecordEntity result = raidRecordRepository.save(requestDto.convertFrom());
         return result.toResponse();
     }
@@ -34,9 +33,8 @@ public class RaidRecordService {
     @Transactional
     public void endRaid (RaidEndRequestDto requestDto) throws NotFoundRaidRecordException, RaidTimeoutException {
         BossStateEntity bossStateEntity = bossStateRepository.findBossState();
-        LocalDateTime endTime = LocalDateTime.now();
 
-        bossStateEntity.validateRaidEnd(endTime, requestDto.getUserId());
+        bossStateEntity.validateRaidEnd(requestDto);
 
         Optional<RaidRecordEntity> raidRecordEntity = raidRecordRepository.findById(requestDto.getRaidRecordId());
 
@@ -45,7 +43,7 @@ public class RaidRecordService {
         }
 
         bossStateRepository.save(bossStateEntity.withRaidingState(false));
-        raidRecordRepository.save(raidRecordEntity.get().withRaidEndTime(endTime));
+        raidRecordRepository.save(raidRecordEntity.get().withRaidEndTime(requestDto.getRaidEndTime()));
         rankingRepositoryImple.save(raidRecordEntity.get());
     }
 

--- a/src/main/java/com/dimsssss/raid/raid/domain/BossStateEntity.java
+++ b/src/main/java/com/dimsssss/raid/raid/domain/BossStateEntity.java
@@ -1,6 +1,7 @@
 package com.dimsssss.raid.raid.domain;
 
 import com.dimsssss.raid.raid.domain.dto.BossStateResponseDto;
+import com.dimsssss.raid.raid.presentation.dto.RaidEndRequestDto;
 import lombok.Getter;
 import org.hibernate.annotations.CreationTimestamp;
 
@@ -107,11 +108,11 @@ public class BossStateEntity {
             throw new RaidTimeoutException("현재 레이드가 진행중입니다");
         }
     }
-    public void validateRaidEnd(LocalDateTime current, Long userId) throws RaidTimeoutException {
-        if (isTimeOut(current)) {
+    public void validateRaidEnd(RaidEndRequestDto requestDto) throws RaidTimeoutException {
+        if (isTimeOut(requestDto.getRaidEndTime())) {
             throw new RaidTimeoutException("주어진 레이드 시간이 지났습니다");
         }
-        if (!this.getLatestRaidUserId().equals(userId)) {
+        if (!this.getLatestRaidUserId().equals(requestDto.getUserId())) {
             throw new IllegalArgumentException("레이드 진행중인 아이디와 종료 아이디가 다릅니다. raidUserId: %s, requestUserId: %s");
         }
     }

--- a/src/main/java/com/dimsssss/raid/raid/presentation/dto/RaidEndRequestDto.java
+++ b/src/main/java/com/dimsssss/raid/raid/presentation/dto/RaidEndRequestDto.java
@@ -3,10 +3,13 @@ package com.dimsssss.raid.raid.presentation.dto;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Builder
 @Getter
 public class RaidEndRequestDto {
     private Long userId;
     private Long raidRecordId;
     private Long bossStateId;
+    private LocalDateTime raidEndTime;
 }

--- a/src/main/java/com/dimsssss/raid/raid/presentation/dto/RaidStartRequestDto.java
+++ b/src/main/java/com/dimsssss/raid/raid/presentation/dto/RaidStartRequestDto.java
@@ -1,18 +1,23 @@
 package com.dimsssss.raid.raid.presentation.dto;
 
 import com.dimsssss.raid.raid.domain.RaidRecordEntity;
+
 import lombok.Builder;
 import lombok.Getter;
+
+import java.time.LocalDateTime;
 
 @Builder
 @Getter
 public class RaidStartRequestDto {
     private Long userId;
     private int level;
+    private LocalDateTime raidStartTime;
 
-    public RaidStartRequestDto(Long userId, int level) {
+    public RaidStartRequestDto(Long userId, int level, LocalDateTime raidStartTime) {
         this.userId = userId;
         this.level = level;
+        this.raidStartTime = raidStartTime;
     }
     public RaidRecordEntity convertFrom() {
         return RaidRecordEntity.builder()

--- a/src/test/java/com/dimsssss/raid/raid/application/RaidRecordServiceTest.java
+++ b/src/test/java/com/dimsssss/raid/raid/application/RaidRecordServiceTest.java
@@ -43,9 +43,11 @@ class RaidRecordServiceTest {
 
     @BeforeEach
     void setup() {
+        LocalDateTime current = LocalDateTime.now();
         requestDto = RaidStartRequestDto.builder()
                 .userId(1L)
                 .level(3)
+                .raidStartTime(current)
                 .build();
 
         raidRecordEntity = RaidRecordEntity.builder()
@@ -58,6 +60,7 @@ class RaidRecordServiceTest {
                 .raidRecordId(1L)
                 .userId(1L)
                 .bossStateId(1L)
+                .raidEndTime(current)
                 .build();
         Mockito.when(raidRecordRepository.save(any(RaidRecordEntity.class))).thenReturn(raidRecordEntity);
     }
@@ -120,6 +123,7 @@ class RaidRecordServiceTest {
                 .raidRecordId(1L)
                 .userId(2L)
                 .bossStateId(1L)
+                .raidEndTime(LocalDateTime.now())
                 .build();
 
         bossStateEntity = new BossStateEntity().withRaidingStateAndStartTime(true, LocalDateTime.now()).withUserId(1L);

--- a/src/test/java/com/dimsssss/raid/raid/presentation/RaidRecordControllerTest.java
+++ b/src/test/java/com/dimsssss/raid/raid/presentation/RaidRecordControllerTest.java
@@ -4,6 +4,7 @@ import com.dimsssss.raid.raid.domain.*;
 import com.dimsssss.raid.raid.presentation.dto.RaidEndRequestDto;
 import com.dimsssss.raid.raid.presentation.dto.RaidStartRequestDto;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
@@ -48,12 +49,19 @@ class RaidRecordControllerTest {
     @MockBean
     RankingRepositoryImple rankingRepositoryImple;
 
+    ObjectMapper objectMapper;
+
+    @BeforeAll
+    void setup() {
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+    }
 
     @DisplayName("POST /bossRaid/enter 호출 시 응답 값과 201을 반환한다")
     @WithMockUser
     @Test
     public void start() throws Exception {
-        RaidStartRequestDto requestDto = new RaidStartRequestDto(1L, 3);
+        RaidStartRequestDto requestDto = new RaidStartRequestDto(1L, 3, LocalDateTime.now());
         BossStateEntity bossStateEntity = Mockito.mock(BossStateEntity.class);
         RaidRecordEntity result = new RaidRecordEntity(1L, 3, 1L);
 
@@ -65,9 +73,11 @@ class RaidRecordControllerTest {
 
         String url = "http://localhost:" + port + "/bossRaid/enter";
 
+
+
         mockMvc.perform(post(url)
                     .contentType(MediaType.APPLICATION_JSON)
-                    .content(new ObjectMapper().writeValueAsString(requestDto))
+                    .content(objectMapper.writeValueAsString(requestDto))
                     .with(csrf()))
             .andExpect(status().isCreated())
             .andExpect(jsonPath("$.raidRecordId", greaterThan(0)))
@@ -78,7 +88,7 @@ class RaidRecordControllerTest {
     @WithMockUser
     @Test
     public void start_fail_when_database_exception () throws Exception {
-        RaidStartRequestDto requestDto = new RaidStartRequestDto(1L, 3);
+        RaidStartRequestDto requestDto = new RaidStartRequestDto(1L, 3, LocalDateTime.now());
         BossStateEntity bossStateEntity = Mockito.mock(BossStateEntity.class);
 
         Mockito.when(bossStateEntity.withRaidingStateAndStartTime(any(Boolean.class), any(LocalDateTime.class))).thenReturn(bossStateEntity);
@@ -89,7 +99,7 @@ class RaidRecordControllerTest {
 
         mockMvc.perform(post(url)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(new ObjectMapper().writeValueAsString(requestDto))
+                        .content(objectMapper.writeValueAsString(requestDto))
                         .with(csrf()))
                 .andExpect(status().is5xxServerError());
     }
@@ -121,7 +131,7 @@ class RaidRecordControllerTest {
 
         mockMvc.perform(patch(url)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(new ObjectMapper().writeValueAsString(requestDto))
+                        .content(objectMapper.writeValueAsString(requestDto))
                         .with(csrf()))
                 .andExpect(status().isOk());
     }


### PR DESCRIPTION
##  시간 객체 생성 제거

더 정확한 시간을 관리하기 위해 서버에서 시간 객체를 생성해서 이벤트 시간을 비교하는 코드를 수정
클라이언트에서 이벤트 발생 시간을 받아서 비교하는 것으로 수정